### PR TITLE
Move the models into a seperate project

### DIFF
--- a/src/Munisio.Models/HateoasCollection.cs
+++ b/src/Munisio.Models/HateoasCollection.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Munisio
+namespace Munisio.Models
 {
     public class HateoasCollection<T> : HateoasObject, IHateoasCollection where T : IHateoasObject
     {

--- a/src/Munisio.Models/HateoasLink.cs
+++ b/src/Munisio.Models/HateoasLink.cs
@@ -1,4 +1,4 @@
-﻿namespace Munisio
+﻿namespace Munisio.Models
 {
     public record HateoasLink(string Rel, string Href, string Method);
 }

--- a/src/Munisio.Models/HateoasObject.cs
+++ b/src/Munisio.Models/HateoasObject.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Munisio
+namespace Munisio.Models
 {
     public class HateoasObject : IHateoasObject
     {

--- a/src/Munisio.Models/IHateoasCollection.cs
+++ b/src/Munisio.Models/IHateoasCollection.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Munisio
+namespace Munisio.Models
 {
     public interface IHateoasCollection
     {

--- a/src/Munisio.Models/IHateoasObject.cs
+++ b/src/Munisio.Models/IHateoasObject.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
+using Munisio.Models;
 
-namespace Munisio
+namespace Munisio.Models
 {
     public interface IHateoasObject
     {

--- a/src/Munisio.Models/Munisio.Models.csproj
+++ b/src/Munisio.Models/Munisio.Models.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Munisio.Models/PagedHateoasCollection.cs
+++ b/src/Munisio.Models/PagedHateoasCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
+using Munisio.Models;
 
-namespace Munisio
+namespace Munisio.Models
 {
     public class PagedHateoasCollection<T> : HateoasCollection<T> where T : IHateoasObject
     {

--- a/src/Munisio.sln
+++ b/src/Munisio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31019.35
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{5979F4A3-147A-47B0-8700-E9C0D0228521}"
 EndProject
@@ -24,6 +24,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{5DE2B62C-8012-4E53-AE96-D1C99DECBA58}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Munisio", "Munisio\Munisio.csproj", "{13BED201-2DAF-4A01-9C81-C5D9232C1CBA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Munisio.Models", "Munisio.Models\Munisio.Models.csproj", "{184E5653-BED5-4324-86CF-B9010993E368}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,18 @@ Global
 		{13BED201-2DAF-4A01-9C81-C5D9232C1CBA}.Release|x64.Build.0 = Release|Any CPU
 		{13BED201-2DAF-4A01-9C81-C5D9232C1CBA}.Release|x86.ActiveCfg = Release|Any CPU
 		{13BED201-2DAF-4A01-9C81-C5D9232C1CBA}.Release|x86.Build.0 = Release|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Debug|x64.Build.0 = Debug|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Debug|x86.Build.0 = Debug|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Release|Any CPU.Build.0 = Release|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Release|x64.ActiveCfg = Release|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Release|x64.Build.0 = Release|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Release|x86.ActiveCfg = Release|Any CPU
+		{184E5653-BED5-4324-86CF-B9010993E368}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Munisio/HateoasActionFilter.cs
+++ b/src/Munisio/HateoasActionFilter.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Munisio.Models;
 
 namespace Munisio
 {

--- a/src/Munisio/IAsyncHateoasProvider.cs
+++ b/src/Munisio/IAsyncHateoasProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Munisio.Models;
 
 namespace Munisio
 {

--- a/src/Munisio/IHateoasProvider.cs
+++ b/src/Munisio/IHateoasProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace Munisio
+﻿using Munisio.Models;
+
+namespace Munisio
 {
     public interface IHateoasProvider<in TModel> where TModel : IHateoasObject
     {

--- a/src/Munisio/Munisio.csproj
+++ b/src/Munisio/Munisio.csproj
@@ -9,4 +9,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Munisio.Models\Munisio.Models.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Move the models into a seperate project so clients can use munisio when they have their models in  a seperate assembly. This way that seperate assesmbly doesnt require a dependency on asp.net core