### PR TITLE
#16: Added option to autoscan and add hateoas providers.

### DIFF
--- a/src/Munisio/ServiceCollectionExtensions.cs
+++ b/src/Munisio/ServiceCollectionExtensions.cs
@@ -20,14 +20,14 @@ namespace Munisio
         }
 
         /// <summary>
-        /// Searches for your <see cref="IHateoasProvider{TModel}"/> and <see cref="IAsyncHateoasProvider{TModel}"/> implementations in your current assembly and registers them in a transient manner to the <paramref name="services"/> you pass in.
+        /// Searches for your <see cref="IHateoasProvider{TModel}"/> and <see cref="IAsyncHateoasProvider{TModel}"/> implementations in the assembly that calls this method and registers them in a transient manner to the <paramref name="services"/> you pass in.
         /// Don't forget to call <see cref="AddHateoas(MvcOptions)"/> so your providers will get executed at runtime!
         /// </summary>
         /// <param name="services"></param>
         /// <remarks>
         /// Calling this method is not required; it's simply convenient. If you don't want Munisio to search and register your implementations automatically, feel free to register them yourself!
         /// </remarks>
-        public static IServiceCollection AddHateoasProviders(this IServiceCollection services) => services.AddHateoasProviders(Assembly.GetExecutingAssembly());
+        public static IServiceCollection AddHateoasProviders(this IServiceCollection services) => services.AddHateoasProviders(Assembly.GetCallingAssembly());
 
         /// <summary>
         /// Searches for your <see cref="IHateoasProvider{TModel}"/> and <see cref="IAsyncHateoasProvider{TModel}"/> implementations in the <paramref name="assemblies"/> you pass in to this method. 

--- a/src/Munisio/ServiceCollectionExtensions.cs
+++ b/src/Munisio/ServiceCollectionExtensions.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Munisio
 {
@@ -11,6 +16,53 @@ namespace Munisio
         {
             builder.Filters.Add<HateoasActionFilter>();
             return builder;
+        }
+
+        public static IServiceCollection AddHateoas(this IServiceCollection services) => services.AddHateoas(Assembly.GetExecutingAssembly());
+
+        public static IServiceCollection AddHateoas(this IServiceCollection services, params Assembly[] assemblies)
+        {
+            if (assemblies.Length == 0)
+            {
+                throw new ArgumentException("No assemblies given to scan");
+            }
+
+            var providedAssemblies = assemblies.Distinct()
+                                               .ToArray();
+
+            var targetHateoasInterfaces = new Type[] {
+                typeof(IHateoasProvider<>)
+                , typeof(IAsyncHateoasProvider<>)
+            };
+
+            foreach (var targetHateoasInterface in targetHateoasInterfaces)
+            {
+                var amountGenericTypeArguments = targetHateoasInterface.GetGenericArguments().Length;
+
+                var typesToRegister = providedAssemblies.SelectMany(assembly => assembly.DefinedTypes)
+                                                        .Where(x => x.GetImplementedHateoasInterfaceTypes(targetHateoasInterface).Any())
+                                                        .Where(x => x.IsClass && !x.IsAbstract)
+                                                        .Select(x => new { @interface = x.ImplementedInterfaces.First(y => y.GetGenericTypeDefinition() == targetHateoasInterface), definedType = x })
+                                                        .ToList();
+
+                foreach (var type in typesToRegister)
+                {
+                    services.AddTransient(targetHateoasInterface.MakeGenericType(type.@interface.GenericTypeArguments), type.definedType);
+                }
+            }
+            return services;
+        }
+
+        private static IEnumerable<Type> GetImplementedHateoasInterfaceTypes(this Type type, Type targetType)
+        {
+            if (type is null) yield break;
+
+            foreach (var interfaceType in type.GetInterfaces()
+                                              .Where(type => type.GetTypeInfo().IsGenericType
+                                                                   && type.GetGenericTypeDefinition() == targetType))
+            {
+                yield return interfaceType;
+            }
         }
     }
 }

--- a/src/Munisio/ServiceCollectionExtensions.cs
+++ b/src/Munisio/ServiceCollectionExtensions.cs
@@ -10,7 +10,8 @@ namespace Munisio
     public static class ServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds Minusio's HATEOAS middleware to the MVC pipeline.
+        /// Adds Munisio's HATEOAS middleware to the MVC pipeline.
+        /// Don't forget to call <see cref="AddHateoasProviders(IServiceCollection)"/> or <see cref="AddHateoasProviders(IServiceCollection, Assembly[])"/> afterwards if you want Munisio to automatically register your HATEOAS providers!
         /// </summary>
         public static MvcOptions AddHateoas(this MvcOptions builder)
         {
@@ -18,9 +19,27 @@ namespace Munisio
             return builder;
         }
 
-        public static IServiceCollection AddHateoas(this IServiceCollection services) => services.AddHateoas(Assembly.GetExecutingAssembly());
+        /// <summary>
+        /// Searches for your <see cref="IHateoasProvider{TModel}"/> and <see cref="IAsyncHateoasProvider{TModel}"/> implementations in your current assembly and registers them in a transient manner to the <paramref name="services"/> you pass in.
+        /// Don't forget to call <see cref="AddHateoas(MvcOptions)"/> so your providers will get executed at runtime!
+        /// </summary>
+        /// <param name="services"></param>
+        /// <remarks>
+        /// Calling this method is not required; it's simply convenient. If you don't want Munisio to search and register your implementations automatically, feel free to register them yourself!
+        /// </remarks>
+        public static IServiceCollection AddHateoasProviders(this IServiceCollection services) => services.AddHateoasProviders(Assembly.GetExecutingAssembly());
 
-        public static IServiceCollection AddHateoas(this IServiceCollection services, params Assembly[] assemblies)
+        /// <summary>
+        /// Searches for your <see cref="IHateoasProvider{TModel}"/> and <see cref="IAsyncHateoasProvider{TModel}"/> implementations in the <paramref name="assemblies"/> you pass in to this method. 
+        /// They will be registered transient manner to the <paramref name="services"/> you pass in.
+        /// 
+        /// Don't forget to call <see cref="AddHateoas(MvcOptions)"/> so your providers will get executed at runtime!
+        /// </summary>
+        /// <param name="services"></param>
+        /// <remarks>
+        /// Calling this method is not required; it's simply convenient. If you don't want Munisio to search and register your implementations automatically, feel free to register them yourself!
+        /// </remarks>
+        public static IServiceCollection AddHateoasProviders(this IServiceCollection services, params Assembly[] assemblies)
         {
             if (assemblies.Length == 0)
             {
@@ -30,10 +49,7 @@ namespace Munisio
             var providedAssemblies = assemblies.Distinct()
                                                .ToArray();
 
-            var targetHateoasInterfaces = new Type[] {
-                typeof(IHateoasProvider<>)
-                , typeof(IAsyncHateoasProvider<>)
-            };
+            var targetHateoasInterfaces = new Type[] { typeof(IHateoasProvider<>), typeof(IAsyncHateoasProvider<>) };
 
             foreach (var targetHateoasInterface in targetHateoasInterfaces)
             {
@@ -57,9 +73,7 @@ namespace Munisio
         {
             if (type is null) yield break;
 
-            foreach (var interfaceType in type.GetInterfaces()
-                                              .Where(type => type.GetTypeInfo().IsGenericType
-                                                                   && type.GetGenericTypeDefinition() == targetType))
+            foreach (var interfaceType in type.GetInterfaces().Where(type => type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == targetType))
             {
                 yield return interfaceType;
             }


### PR DESCRIPTION
Added an extension function which scans given assemblies, or default the executing assembly, for classes that implement IHateoasProvider<T>. Users of this library will now only need to call Builder.Services.AddHateoas(<Or with param Assembly[] assemblies>)


- Services are always added as Transient at the moment, multiple services implementing the same Type parameter are also still possible.